### PR TITLE
feat: add document name

### DIFF
--- a/api/dsr/v1/Access.md
+++ b/api/dsr/v1/Access.md
@@ -192,6 +192,7 @@ Authorization: $auth
         }
       },
       {
+        "name": "secondresult.json",
         "data": "eyJrZXkiOiAidmFsdWUifQ==",
         "headers": {
           "Content-Type": "application/json"

--- a/api/dsr/v1/README.md
+++ b/api/dsr/v1/README.md
@@ -37,7 +37,8 @@ The protocol for communicating with the Callback is defined for every object tha
 
 ### Document
 
-The Document object defines a way of providing document data to the Ketch platform.
+The Document object defines a way of providing document data to the Ketch platform. An optional `name` can
+be specified for the Document.
 
 #### As a Callback
 

--- a/openapi/components/schemas/AccessResponse.yaml
+++ b/openapi/components/schemas/AccessResponse.yaml
@@ -13,11 +13,26 @@ properties:
   requestID:
     type: string
     description: the request ID known in the destination system
+  results:
+    type: array
+    items:
+      $ref: "./Document.yaml"
+  documents:
+    type: array
+    items:
+      $ref: "./Document.yaml"
+  context:
+    type: object
+  outcome:
+    type: object
+  subject:
+    type: object
+  identities:
+    type: array
+    description: array of Identities
+    items:
+      $ref: "./Identity.yaml"
 #  redirectUrl:
 #    type: string
 #    format: url
 #    description: if the Data Subject should be redirected to a URL (perhaps for confirmation), this field specifies the URL to redirect the Data Subject to
-  results:
-    type: array
-    items:
-      $ref: "./Callback.yaml"

--- a/openapi/components/schemas/CorrectionResponse.yaml
+++ b/openapi/components/schemas/CorrectionResponse.yaml
@@ -13,6 +13,25 @@ properties:
   requestID:
     type: string
     description: the request ID known in the destination system
+  results:
+    type: array
+    items:
+      $ref: "./Document.yaml"
+  documents:
+    type: array
+    items:
+      $ref: "./Document.yaml"
+  context:
+    type: object
+  outcome:
+    type: object
+  subject:
+    type: object
+  identities:
+    type: array
+    description: array of Identities
+    items:
+      $ref: "./Identity.yaml"
 #  redirectUrl:
 #    type: string
 #    format: url

--- a/openapi/components/schemas/DeleteResponse.yaml
+++ b/openapi/components/schemas/DeleteResponse.yaml
@@ -13,6 +13,25 @@ properties:
   requestID:
     type: string
     description: the request ID known in the destination system
+  results:
+    type: array
+    items:
+      $ref: "./Document.yaml"
+  documents:
+    type: array
+    items:
+      $ref: "./Document.yaml"
+  context:
+    type: object
+  outcome:
+    type: object
+  subject:
+    type: object
+  identities:
+    type: array
+    description: array of Identities
+    items:
+      $ref: "./Identity.yaml"
 #  redirectUrl:
 #    type: string
 #    format: url

--- a/openapi/components/schemas/Document.yaml
+++ b/openapi/components/schemas/Document.yaml
@@ -1,0 +1,16 @@
+type: object
+properties:
+  name:
+    type: string
+    description: Name of the result
+  data:
+    type: string
+    description: Base64-encoded data
+  url:
+    type: string
+    description: URL of the endpoint to download results. Must be publicly accessible or accessible using the given headers
+  headers:
+    type: object
+    additionalProperties:
+      type: string
+    description: map of headers to send to the endpoint

--- a/openapi/components/schemas/RestrictProcessingResponse.yaml
+++ b/openapi/components/schemas/RestrictProcessingResponse.yaml
@@ -13,6 +13,25 @@ properties:
   requestID:
     type: string
     description: the request ID known in the destination system
+  results:
+    type: array
+    items:
+      $ref: "./Document.yaml"
+  documents:
+    type: array
+    items:
+      $ref: "./Document.yaml"
+  context:
+    type: object
+  outcome:
+    type: object
+  subject:
+    type: object
+  identities:
+    type: array
+    description: array of Identities
+    items:
+      $ref: "./Identity.yaml"
 #  redirectUrl:
 #    type: string
 #    format: url

--- a/openapi/components/schemas/_index.yaml
+++ b/openapi/components/schemas/_index.yaml
@@ -46,6 +46,8 @@ CorrectionResponse:
   $ref: "./CorrectionResponse.yaml"
 ResponseKind:
   $ref: "./ResponseKind.yaml"
+Document:
+  $ref: "./Document.yaml"
 DSRRequestStatusReason:
   $ref: "./DSRRequestStatusReason.yaml"
 Identity:

--- a/openapi/forwarder_gen.yaml
+++ b/openapi/forwarder_gen.yaml
@@ -65,7 +65,22 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/Callback'
+            $ref: '#/components/schemas/Document'
+        documents:
+          type: array
+          items:
+            $ref: '#/components/schemas/Document'
+        context:
+          type: object
+        outcome:
+          type: object
+        subject:
+          type: object
+        identities:
+          type: array
+          description: array of Identities
+          items:
+            $ref: '#/components/schemas/Identity'
     DeleteResponse:
       type: object
       properties:
@@ -82,6 +97,25 @@ components:
         requestID:
           type: string
           description: the request ID known in the destination system
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Document'
+        documents:
+          type: array
+          items:
+            $ref: '#/components/schemas/Document'
+        context:
+          type: object
+        outcome:
+          type: object
+        subject:
+          type: object
+        identities:
+          type: array
+          description: array of Identities
+          items:
+            $ref: '#/components/schemas/Identity'
     Request:
       type: object
       description: Request
@@ -110,6 +144,25 @@ components:
         requestID:
           type: string
           description: the request ID known in the destination system
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Document'
+        documents:
+          type: array
+          items:
+            $ref: '#/components/schemas/Document'
+        context:
+          type: object
+        outcome:
+          type: object
+        subject:
+          type: object
+        identities:
+          type: array
+          description: array of Identities
+          items:
+            $ref: '#/components/schemas/Identity'
     Error:
       type: object
       properties:
@@ -446,6 +499,25 @@ components:
         requestID:
           type: string
           description: the request ID known in the destination system
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Document'
+        documents:
+          type: array
+          items:
+            $ref: '#/components/schemas/Document'
+        context:
+          type: object
+        outcome:
+          type: object
+        subject:
+          type: object
+        identities:
+          type: array
+          description: array of Identities
+          items:
+            $ref: '#/components/schemas/Identity'
     ResponseKind:
       type: string
       enum:
@@ -453,6 +525,23 @@ components:
         - CorrectionResponse
         - DeleteResponse
         - RestrictProcessingResponse
+    Document:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Name of the result
+        data:
+          type: string
+          description: Base64-encoded data
+        url:
+          type: string
+          description: URL of the endpoint to download results. Must be publicly accessible or accessible using the given headers
+        headers:
+          type: object
+          additionalProperties:
+            type: string
+          description: map of headers to send to the endpoint
     DSRRequestStatusReason:
       type: string
       enum:

--- a/openapi/index_gen.yaml
+++ b/openapi/index_gen.yaml
@@ -65,7 +65,22 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/Callback'
+            $ref: '#/components/schemas/Document'
+        documents:
+          type: array
+          items:
+            $ref: '#/components/schemas/Document'
+        context:
+          type: object
+        outcome:
+          type: object
+        subject:
+          type: object
+        identities:
+          type: array
+          description: array of Identities
+          items:
+            $ref: '#/components/schemas/Identity'
     DeleteResponse:
       type: object
       properties:
@@ -82,6 +97,25 @@ components:
         requestID:
           type: string
           description: the request ID known in the destination system
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Document'
+        documents:
+          type: array
+          items:
+            $ref: '#/components/schemas/Document'
+        context:
+          type: object
+        outcome:
+          type: object
+        subject:
+          type: object
+        identities:
+          type: array
+          description: array of Identities
+          items:
+            $ref: '#/components/schemas/Identity'
     Request:
       type: object
       description: Request
@@ -110,6 +144,25 @@ components:
         requestID:
           type: string
           description: the request ID known in the destination system
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Document'
+        documents:
+          type: array
+          items:
+            $ref: '#/components/schemas/Document'
+        context:
+          type: object
+        outcome:
+          type: object
+        subject:
+          type: object
+        identities:
+          type: array
+          description: array of Identities
+          items:
+            $ref: '#/components/schemas/Identity'
     Error:
       type: object
       properties:
@@ -446,6 +499,25 @@ components:
         requestID:
           type: string
           description: the request ID known in the destination system
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Document'
+        documents:
+          type: array
+          items:
+            $ref: '#/components/schemas/Document'
+        context:
+          type: object
+        outcome:
+          type: object
+        subject:
+          type: object
+        identities:
+          type: array
+          description: array of Identities
+          items:
+            $ref: '#/components/schemas/Identity'
     ResponseKind:
       type: string
       enum:
@@ -453,6 +525,23 @@ components:
         - CorrectionResponse
         - DeleteResponse
         - RestrictProcessingResponse
+    Document:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Name of the result
+        data:
+          type: string
+          description: Base64-encoded data
+        url:
+          type: string
+          description: URL of the endpoint to download results. Must be publicly accessible or accessible using the given headers
+        headers:
+          type: object
+          additionalProperties:
+            type: string
+          description: map of headers to send to the endpoint
     DSRRequestStatusReason:
       type: string
       enum:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Code generated by shipbuilder init 1.21.7. DO NOT EDIT. -->

## Description of this change
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Add document name

## Why is this change being made?
- [ ] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
N/A

## Related issues
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X ] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [X] I have informed stakeholders of my changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and OpenAPI-only changes with an optional new field; `Document` remains backward compatible with URL/header-style results previously typed as `Callback`.
> 
> **Overview**
> Adds an optional **`name`** on DSR **`Document`** payloads so integrators can label result files (e.g. `secondresult.json`), with docs updated in **`api/dsr/v1`** and an Access status event example.
> 
> Introduces **`openapi/components/schemas/Document.yaml`** (`name`, `data`, `url`, `headers`) and wires it into DSR response schemas: **`results`** (and **`documents`**) now reference **`Document`** instead of **`Callback`**, and Access/Correction/Delete/RestrictProcessing response OpenAPI components gain the augmentation fields (**`context`**, **`outcome`**, **`subject`**, **`identities`**, etc.) aligned with the API docs. Generated **`forwarder_gen.yaml`** / **`index_gen.yaml`** are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfda9c0c3e6589e0785fd4ac99002c42d1a39e10. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->