### PR TITLE
Update Access.md

### DIFF
--- a/api/dsr/v1/Access.md
+++ b/api/dsr/v1/Access.md
@@ -97,7 +97,7 @@ specified in the request.
 The `results` and `documents` are merged with any cached results from previous events. New documents are
 added and existing documents are updated.
 
-Once the status is set to `completed`, `cancelled` or `denied`, then no further events will be accepted.
+Once the status is set to `completed`, `in_progress` or `pending`, then no further events will be accepted.
 
 The `Content-Type` MUST be `application/json`.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Code generated by shipbuilder init 1.21.7. DO NOT EDIT. -->

## Description of this change
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
> Description here

## Why is this change being made?
- [ ] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Related issues
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> This is a contract change for Access integrations and conflicts with shared status semantics elsewhere in the DSR docs, so implementers may reject valid events or diverge from platform behavior.
> 
> **Overview**
> Updates the **Access** API spec so that **no further `AccessStatusEvent` callbacks are accepted** once status is `completed`, `in_progress`, or `pending`—replacing the previous terminal set of `completed`, `cancelled`, and `denied`.
> 
> This is documentation-only in `api/dsr/v1/Access.md` and does not align with other DSR request docs (e.g. Delete/Correction) or `Status.md`, which still treat `in_progress` as non-terminal and allow repeated events until `completed`, `cancelled`, or `denied`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2062de5494b98b9067661a1d86ba3c73f2b4bec. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->