### PR TITLE
Update Correction.md

### DIFF
--- a/api/dsr/v1/Correction.md
+++ b/api/dsr/v1/Correction.md
@@ -94,7 +94,7 @@ The `results` and `documents` are merged with any cached results from previous e
 added and existing documents are updated.
 
 When the status of Correction Request has changed, a `CorrectionStatusEvent` JSON object should be sent to all the
-callbacks specified in the request. Once the status is set to `completed`, `cancelled` or `denied`, then no further
+callbacks specified in the request. Once the status is set to `completed`, `in_progress` or `pending`, then no further
 events will be accepted.
 
 The `Content-Type` MUST be `application/json`.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Code generated by shipbuilder init 1.21.7. DO NOT EDIT. -->

## Description of this change
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
> Description here

## Why is this change being made?
- [ ] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Related issues
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public DSR integration spec change that could cause wrong callback handling if implemented as written; documentation-only but affects partner behavior.
> 
> **Overview**
> **Correction API docs (`api/dsr/v1/Correction.md`)** — In the “Correction Response / Status Event” section, the sentence that defines when no further `CorrectionStatusEvent` callbacks are accepted now lists **`completed`, `in_progress`, and `pending`** instead of **`completed`, `cancelled`, and `denied`**.
> 
> That is a substantive contract change for integrators: under the new text, sending `in_progress` or `pending` would close the request to further events, which conflicts with the same page’s examples (response with `in_progress`, event with `pending`) and with **`Status.md` / Access / Delete / RestrictProcessing**, where only terminal outcomes stop further events and `in_progress` may repeat until completion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4d6b4d4f172ab1bbfd1f49df7a6cca8f8d3019c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->