### PR TITLE
Update Delete.md

### DIFF
--- a/api/dsr/v1/Delete.md
+++ b/api/dsr/v1/Delete.md
@@ -101,7 +101,7 @@ added and existing documents are updated.
 When the status of Delete Request has changed, a `DeleteStatusEvent` event should be sent to all the callbacks specified
 in the request.
 
-Once the status is set to `completed`, `cancelled` or `denied`, then no further events will be accepted.
+Once the status is set to `completed`, `in_progress` or `pending`, then no further events will be accepted.
 
 The `Content-Type` MUST be `application/json`.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Code generated by shipbuilder init 1.21.7. DO NOT EDIT. -->

## Description of this change
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
> Description here

## Why is this change being made?
- [ ] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Related issues
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Documentation-only but changes the Delete callback lifecycle in a way that conflicts with other DSR v1 specs and could mislead implementers or break multi-event `in_progress` flows if taken as authoritative.
> 
> **Overview**
> Updates **`api/dsr/v1/Delete.md`** so that after a Delete request reaches certain statuses, **no further `DeleteStatusEvent` callbacks are accepted**.
> 
> The rule changes from terminal statuses **`completed`**, **`cancelled`**, and **`denied`** to **`completed`**, **`in_progress`**, and **`pending`**. That is a behavioral contract change for Delete integrations: **`in_progress` and `pending` would block later events**, whereas other DSR v1 docs (e.g. Access, Correction) still only close the event stream on **`completed` / `cancelled` / `denied`**, and **`Status.md`** still allows repeated **`in_progress`** updates until a final outcome.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 266b91b5db1e7889e597204575d7e4618477e13a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->