### PR TITLE
fix: upgrade conventional-actions to node24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         fetch-depth: 0
     - name: Generate next version
       id: version
-      uses: conventional-actions/next-version@v1
+      uses: conventional-actions/next-version@1b3e4803a0bdf7435ba7bb5ace077445ed54e82a # v1.1.8
     - name: Generating PDF
       uses: baileyjm02/markdown-to-pdf@v1
       with:
@@ -36,7 +36,7 @@ jobs:
         name: specification
         path: pdfs
     - name: Create Release
-      uses: conventional-actions/create-release@v1
+      uses: conventional-actions/create-release@c025b7306d14a25901b72486f97f3ebe7662a8ed # v1.0.31
       if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
       with:
         tag_name: ${{ steps.version.outputs.version }}


### PR DESCRIPTION
## Summary

Upgrade conventional-actions to node24-compatible releases:

- `conventional-actions/next-version` → **v1.1.8** (`1b3e480`)
- `conventional-actions/create-release` → **v1.0.31** (`c025b73`)

Node 20 reaches EOL April 2026 and GitHub is forcing migration to node24 by June 2026.

### Upstream PRs

- https://github.com/conventional-actions/next-version/pull/96
- https://github.com/conventional-actions/create-release/pull/8

## Test plan

- [ ] CI passes on this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only updates GitHub Actions references for release/versioning steps, without changing application/runtime code. Primary risk is CI/release automation behavior differences from the updated action versions.
> 
> **Overview**
> Pins CI workflow `conventional-actions/next-version` and `conventional-actions/create-release` from floating `@v1` to specific commit SHAs (`v1.1.8` and `v1.0.31`) to stay compatible with newer Node runtimes used by GitHub Actions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c9412f3e5389b0fc655ab18636774939a93f5c2. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->